### PR TITLE
Simplified advice setup and tweak ordering.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,5 +148,12 @@
 			</plugin>
 		</plugins>
 	</build>
+	
+	<repositories>
+		<repository>
+			<id>spring-libs-milestone</id>
+			<url>https://repo.spring.io/libs-milestone</url>
+		</repository>
+	</repositories>
 
 </project>

--- a/src/main/java/com/demo/SpringTrainingApplication.java
+++ b/src/main/java/com/demo/SpringTrainingApplication.java
@@ -1,41 +1,22 @@
 package com.demo;
 
-import org.aspectj.lang.Aspects;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Bean;
-
-import com.demo.aop.MetricsAspect;
-import com.demo.messaging.MessageSender;
 
 @EnableCaching
 @SpringBootApplication
 public class SpringTrainingApplication implements HealthIndicator {
-	
+
 	@Override
 	public Health health() {
 		return Health.up().withDetail("hello", "world").build();
 	}
 
-	
-	@Bean
-	public MetricsAspect metricsAdvice(MessageSender messageSender) {
-		if( Aspects.hasAspect(MetricsAspect.class)) {
-			return Aspects.aspectOf(MetricsAspect.class);
-		}
-		else { 	// for JUnit tests only
-			MetricsAspect metricsAdvice = new MetricsAspect();
-			metricsAdvice.setMessageSender(messageSender);
-			return metricsAdvice;
-		}
+	public static void main(String[] args) {
+		SpringApplication.run(SpringTrainingApplication.class, args);
 	}
 
-	
-    public static void main(String[] args) {
-    	SpringApplication.run(SpringTrainingApplication.class, args);
-    }
-    
 }

--- a/src/main/java/com/demo/aop/MetricsAspect.java
+++ b/src/main/java/com/demo/aop/MetricsAspect.java
@@ -6,42 +6,36 @@ import org.aspectj.lang.annotation.Aspect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 
 import com.demo.messaging.MessageSender;
 
 @Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE - 10)
 public class MetricsAspect {
 	private static Logger log = LoggerFactory.getLogger(MetricsAspect.class);
 
-	
-	@Autowired
-	private MessageSender messageSender;
-	
-	
-	@Around("com.demo.aop.MetricsPointcuts.serviceCalls()")
-	public Object metrics(ProceedingJoinPoint point)  throws Throwable {
-	
+	@Autowired private MessageSender messageSender;
+
+	@Around("execution(public * (@com.demo.aop.Monitored com.demo..*).*(..))")
+	public Object metrics(ProceedingJoinPoint point) throws Throwable {
+
 		StopWatch timer = new StopWatch("Metrics Watch");
 		final Object value;
 		try {
 			timer.start(point.toShortString());
-			value = point.proceed();			
-		    return value;
-		}
-		finally {
+			value = point.proceed();
+			return value;
+		} finally {
 			timer.stop();
 			log.info(timer.prettyPrint());
-			
+
 			messageSender.send(timer.shortSummary());
 
 		}
-		
 	}
-	
-	// Setter for construction from JUnit tests
-	public void setMessageSender(MessageSender messageSender) {
-		this.messageSender = messageSender;
-	}
-	
 }

--- a/src/test/java/com/demo/ApplicationTests.java
+++ b/src/test/java/com/demo/ApplicationTests.java
@@ -1,19 +1,24 @@
 package com.demo;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.demo.game.service.api.GameService;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = SpringTrainingApplication.class)
 public class ApplicationTests {
 	private static Logger log = LoggerFactory.getLogger(ApplicationTests.class);
-	
+
+	@Autowired GameService service;
+
 	@Test
 	public void contextLoads() {
 		log.info("TEST");
 	}
-
 }


### PR DESCRIPTION
Added milestone repo to be able to resolve Spring Cloud dependencies. Removed manual bean definition for monitoring advice and use component scanning instead. Inlined pointcut expression and explicitly configured order to make sure the advice is applied before caching and transactions.

To verify ordering debug the ApplicationTests put a breakpoint in the method. The autowired GameService then has a advisors property nested behind the proxy. Inspect it to verify the ordering.
